### PR TITLE
[DO-4302][minor] fe fix display of number of quality investigations alerts

### DIFF
--- a/frontend/src/app/mocks/services/dashboard-mock/dashboard.model.ts
+++ b/frontend/src/app/mocks/services/dashboard-mock/dashboard.model.ts
@@ -24,6 +24,6 @@ import { DashboardStatsResponse } from '@page/dashboard/model/dashboard.model';
 export const mockDashboardStats: DashboardStatsResponse = {
   otherParts: 5,
   myParts: 3,
-  investigations: 20,
-  alerts: 101,
+  investigationsReceived: 20,
+  alertsReceived: 101,
 };

--- a/frontend/src/app/modules/page/dashboard/abstraction/dashboard.facade.ts
+++ b/frontend/src/app/modules/page/dashboard/abstraction/dashboard.facade.ts
@@ -96,8 +96,8 @@ export class DashboardFacade {
       next: (dashboardStats: DashboardStats) => {
         this.dashboardState.setNumberOfMyParts({ data: dashboardStats.myParts });
         this.dashboardState.setNumberOfOtherParts({ data: dashboardStats.otherParts });
-        this.dashboardState.setNumberOfInvestigations({ data: dashboardStats.investigations || 0 });
-        this.dashboardState.setNumberOfAlerts({ data: dashboardStats.alerts || 0 });
+        this.dashboardState.setNumberOfInvestigations({ data: dashboardStats.investigationsReceived || 0 });
+        this.dashboardState.setNumberOfAlerts({ data: dashboardStats.alertsReceived || 0 });
       },
       error: error => {
         this.dashboardState.setNumberOfMyParts({ error });

--- a/frontend/src/app/modules/page/dashboard/core/dashboard.assembler.spec.ts
+++ b/frontend/src/app/modules/page/dashboard/core/dashboard.assembler.spec.ts
@@ -32,8 +32,8 @@ describe('DashboardAssembler', () => {
       ).toEqual({
         otherParts: 100,
         myParts: 200,
-        investigations: undefined,
-        alerts: undefined,
+        investigationsReceived: undefined,
+        alertsReceived: undefined,
       });
     });
   });

--- a/frontend/src/app/modules/page/dashboard/core/dashboard.assembler.ts
+++ b/frontend/src/app/modules/page/dashboard/core/dashboard.assembler.ts
@@ -26,8 +26,8 @@ export class DashboardAssembler {
     return {
       otherParts: dashboard.otherParts,
       myParts: dashboard.myParts,
-      investigations: dashboard.investigations,
-      alerts: dashboard.alerts,
+      investigationsReceived: dashboard.investigationsReceived,
+      alertsReceived: dashboard.alertsReceived,
     };
   }
 }

--- a/frontend/src/app/modules/page/dashboard/model/dashboard.model.ts
+++ b/frontend/src/app/modules/page/dashboard/model/dashboard.model.ts
@@ -22,13 +22,13 @@
 export interface DashboardStats {
   otherParts: number | null;
   myParts: number;
-  investigations?: number;
-  alerts?: number;
+  investigationsReceived?: number;
+  alertsReceived?: number;
 }
 
 export interface DashboardStatsResponse {
   otherParts: number | null;
   myParts: number;
-  investigations?: number;
-  alerts?: number;
+  investigationsReceived?: number;
+  alertsReceived?: number;
 }

--- a/frontend/src/app/modules/shared/components/card-icon/card-icon.component.scss
+++ b/frontend/src/app/modules/shared/components/card-icon/card-icon.component.scss
@@ -29,8 +29,6 @@
   border-radius: 15px;
   padding: 20px;
   gap: 20px;
-  overflow: hidden;
-  white-space: nowrap;
   box-shadow: 0px 15px 25px 0px #3333330d, -10px -10px 15px 0px #ffffff1a, 0px 0px 25px 0px #33333308;
 
   &:hover {
@@ -57,7 +55,6 @@
 .label-container {
   @apply flex flex-col;
   justify-content: space-between;
-  height: 48px;
   padding-bottom: 5px;
 }
 

--- a/frontend/src/assets/locales/de/page.dashboard.json
+++ b/frontend/src/assets/locales/de/page.dashboard.json
@@ -1,16 +1,16 @@
 {
   "pageDashboard": {
     "totalInvestigations": {
-      "label": "Anzahl offener Untersuchungen"
+      "label": "Offene Untersuchungen"
     },
     "totalOfMyParts": {
-      "label": "Anzahl meiner Teile"
+      "label": "Meine Produkte"
     },
     "totalOfOtherParts": {
-      "label": "Anzahl geteilter Teile"
+      "label": "Andere Produkte"
     },
     "totalAlerts": {
-      "label": "Anzahl der Qualitätswarnungen"
+      "label": "Offene Warnungen"
     }
   }
 }

--- a/frontend/src/assets/locales/en/page.dashboard.json
+++ b/frontend/src/assets/locales/en/page.dashboard.json
@@ -1,16 +1,16 @@
 {
   "pageDashboard": {
     "totalInvestigations": {
-      "label": "Total of open investigations"
+      "label": "Open investigations"
     },
     "totalOfMyParts": {
-      "label": "Total of my parts"
+      "label": "My parts"
     },
     "totalOfOtherParts": {
-      "label": "Total of shared parts"
+      "label": "Shared parts"
     },
     "totalAlerts": {
-      "label": "Total of quality alerts"
+      "label": "Open alerts"
     }
   }
 }


### PR DESCRIPTION
Changed dashboard api call response handling to fit the new back end response.
Also changed the labeling of the dashboard cards to fit the new naming.