### PR TITLE
Reference same sonar token for frontend and backend 

### DIFF
--- a/.github/workflows/pull-request_backend.yml
+++ b/.github/workflows/pull-request_backend.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Verify Sonar Scan
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND  }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION }}
           SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY_BACKEND }}
         run: mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --batch-mode sonar:sonar -Dsonar.coverage.jacoco.xmlReportPaths=/home/runner/work/tx-traceability-foss/tx-traceability-foss/tx-coverage/target/site/jacoco-aggregate/jacoco.xml -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY_BACKEND }} -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}

--- a/.github/workflows/sonar-scan-backend.yml
+++ b/.github/workflows/sonar-scan-backend.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Verify Sonar Scan
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION }}
           SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY_BACKEND }}
         run: mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --batch-mode sonar:sonar -Dsonar.coverage.jacoco.xmlReportPaths=/home/runner/work/tx-traceability-foss/tx-traceability-foss/tx-coverage/target/site/jacoco-aggregate/jacoco.xml -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY_BACKEND }} -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}

--- a/.github/workflows/sonar-scan-frontend.yml
+++ b/.github/workflows/sonar-scan-frontend.yml
@@ -50,7 +50,7 @@ jobs:
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_FRONTEND }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           projectBaseDir: frontend
           args: >

--- a/.github/workflows/unit-test_frontend.yml
+++ b/.github/workflows/unit-test_frontend.yml
@@ -50,7 +50,7 @@ jobs:
       uses: SonarSource/sonarcloud-github-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_FRONTEND }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       with:
         projectBaseDir: frontend
         args: >


### PR DESCRIPTION
## [ABC-86](https://cofinity-x.atlassian.net/browse/ABC-86)  Consume sonar token from organization secrets

## What type of PR is this?
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Code Refactor
- [X] CICD
- [ ] Revert

## Reference sonar token from organization secrets


## Token was reference from repository secrets and the token had expired


## Organization token is active and acces to sonar is provided 


## How to test

## Added Tests
- [ ] Yes
- [X] No : _Details [Mandatory when no tests are added]_

[ABC-86]: https://cofinity-x.atlassian.net/browse/ABC-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ