### PR TITLE
fix:[BA-935] Fixed fields missing in global search

### DIFF
--- a/cfx-frontend/src/app/modules/shared/helper/filter-helper.ts
+++ b/cfx-frontend/src/app/modules/shared/helper/filter-helper.ts
@@ -109,10 +109,16 @@ export function toGlobalSearchAssetFilter(formValues: string, isAsBuilt: boolean
   if (isAsBuilt) {
     filter = {
       id: formValues,
-      semanticModelId: formValues,
       idShort: formValues,
+      semanticModelId: formValues,
       customerPartId: formValues,
+      manufacturerName: formValues,
+      nameAtManufacturer: formValues,
+      businessPartner: formValues,
+      classification: formValues,
       manufacturerPartId: formValues,
+      nameAtCustomer: formValues,
+      manufacturingCountry: formValues
     } as AssetAsBuiltFilter;
   } else {
     filter = {
@@ -120,6 +126,11 @@ export function toGlobalSearchAssetFilter(formValues: string, isAsBuilt: boolean
       idShort: formValues,
       semanticModelId: formValues,
       manufacturerPartId: formValues,
+      nameAtManufacturer: formValues,
+      manufacturerName: formValues,
+      businessPartner: formValues,
+      classification: formValues,
+      catenaXSiteId: formValues,
     } as AssetAsPlannedFilter;
   }
 


### PR DESCRIPTION
Added missing fields to the global search for as_built and _as_planned tables